### PR TITLE
fix: add future package to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ matplotlib
 seaborn
 python-dotenv
 dronekit
+future
 pymavlink
 litellm
 ollama


### PR DESCRIPTION
- Add missing 'future' dependency required by dronekit library
- Resolves 'No module named past' error when importing dronekit
- The 'past' module is part of the 'future' package for Python 2/3 compatibility